### PR TITLE
Applink handling improvements.

### DIFF
--- a/kalturaPlay/src/main/AndroidManifest.xml
+++ b/kalturaPlay/src/main/AndroidManifest.xml
@@ -35,10 +35,7 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
 
-                <data
-                    android:host="kalturaplay.appspot.com"
-                    android:pathPrefix="/play"
-                    android:scheme="https"/>
+                <data android:host="kgit.html5video.org" android:pathPrefix="/kplay" android:scheme="https"/>
             </intent-filter>
         </activity>
 

--- a/kalturaPlay/src/main/java/com/kaltura/kalturaplayertoolkit/MainActivity.java
+++ b/kalturaPlay/src/main/java/com/kaltura/kalturaplayertoolkit/MainActivity.java
@@ -15,9 +15,6 @@ import android.webkit.WebView;
 
 import com.kaltura.playersdk.KPPlayerConfig;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-
 
 public class MainActivity extends Activity implements LoginFragment.OnFragmentInteractionListener, PlayerFragment.OnFragmentInteractionListener, FullscreenFragment.OnFragmentInteractionListener{
 	public static String TAG = MainActivity.class.getSimpleName();
@@ -88,21 +85,20 @@ public class MainActivity extends Activity implements LoginFragment.OnFragmentIn
 
         if (Intent.ACTION_VIEW.equals( intent.getAction())) {
             Uri uri = intent.getData();
-            String url = null;
-            try {
-                url = URLDecoder.decode(uri.toString(), "UTF-8").replace("https://kalturaplay.appspot.com/play?", "");
-            } catch (UnsupportedEncodingException e) {
-                Log.w(TAG, "couldn't decode/split intent url");
-                e.printStackTrace();
-            }
-            if (url != null) {
-                extras.putSerializable("config", KPPlayerConfig.valueOf(url));
-                fragment = new FullscreenFragment();
 
-            } else {
-                Log.w(TAG, "didn't load iframe, invalid iframeUrl parameter was passed");
+            if (uri == null) {
+                Log.e(TAG, "Can't load player; no data uri");
+                return;
             }
-
+            
+            String embedFrameURL = uri.getQueryParameter("embedFrameURL");
+            if (embedFrameURL == null) {
+                Log.e(TAG, "Can't load player; uri does not contain embedFrameURL parameter");
+                return;
+            }
+            
+            extras.putSerializable("config", KPPlayerConfig.valueOf(embedFrameURL));
+            fragment = new FullscreenFragment();
         }
 
         FragmentUtilities.loadFragment(false, fragment, extras, getFragmentManager());


### PR DESCRIPTION
Changed intent filter URL to https://kgit.html5video.org/kplay.
The embed frame URL is encoded, and passed as parameter "embedFrameURL".
Android 6 autoverify not enabled yet; it requires building with SDK 23.