### PR TITLE
Some cleanup in playerSDK's manifest.

### DIFF
--- a/playerSDK/src/main/AndroidManifest.xml
+++ b/playerSDK/src/main/AndroidManifest.xml
@@ -1,19 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.kplayersdk">
+    package="com.kaltura.playersdk">
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-sdk
-        android:minSdkVersion="15"
-        android:targetSdkVersion="19" />
-
-    <android:uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-         />
-    <android:uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <android:uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-         />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/playerSDK/src/main/java/com/kaltura/playersdk/BrowserActivity.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/BrowserActivity.java
@@ -10,7 +10,7 @@ import android.view.MenuItem;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import com.example.kplayersdk.R;
+import com.kaltura.playersdk.R;
 
 public class BrowserActivity extends Activity {
 

--- a/playerSDK/src/main/java/com/kaltura/playersdk/actionHandlers/ShareStrategies/WebShareStrategy.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/actionHandlers/ShareStrategies/WebShareStrategy.java
@@ -3,7 +3,7 @@ package com.kaltura.playersdk.actionHandlers.ShareStrategies;
 import android.app.Activity;
 import android.content.Intent;
 
-import com.example.kplayersdk.R;
+import com.kaltura.playersdk.R;
 import com.kaltura.playersdk.BrowserActivity;
 import com.kaltura.playersdk.actionHandlers.ShareManager;
 


### PR DESCRIPTION
Changed package name from com.example.kplayersdk to com.kaltura.playersdk.
Removed legacy "uses-sdk" declaration.
Changed files that were using the old name.