### PR TITLE
acquire rights failure - process DRM info failed

### DIFF
--- a/playerSDK/src/main/java/com/kaltura/playersdk/players/KWVCPlayer.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/players/KWVCPlayer.java
@@ -373,7 +373,10 @@ public class KWVCPlayer
             }
         });
         mPlayer.setVideoURI(Uri.parse(widevineUri));
-        mDrmClient.acquireRights(widevineUri, mLicenseUri);
+
+        if(mDrmClient.needToAcquireRights(widevineUri)) {
+            mDrmClient.acquireRights(widevineUri, mLicenseUri);
+        }
     }
 
     private enum PrepareState {

--- a/playerSDK/src/main/java/com/kaltura/playersdk/players/KWVCPlayer.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/players/KWVCPlayer.java
@@ -374,8 +374,8 @@ public class KWVCPlayer
         });
         mPlayer.setVideoURI(Uri.parse(widevineUri));
 
-        if(mDrmClient.needToAcquireRights(widevineUri)) {
-            mDrmClient.acquireRights(widevineUri, mLicenseUri);
+        if(mDrmClient.needToAcquireRights(mAssetUri)) {
+            mDrmClient.acquireRights(mAssetUri, mLicenseUri);
         }
     }
 

--- a/playerSDK/src/main/java/com/kaltura/playersdk/widevine/WidevineDrmClient.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/widevine/WidevineDrmClient.java
@@ -280,6 +280,21 @@ public class WidevineDrmClient {
         }
     }
 
+    /**
+     * returns whether or not we should acquire rights for this url
+     *
+     * @param assetUri
+     * @return
+     */
+    public boolean needToAcquireRights(String assetUri){
+        mDrmManager.acquireDrmInfo(createDrmInfoRequest(assetUri));
+        int rightsStatus = mDrmManager.checkRightsStatus(assetUri);
+        if(rightsStatus == DrmStore.RightsStatus.RIGHTS_INVALID){
+            mDrmManager.removeRights(assetUri); // clear current invalid rights and re-acquire new rights
+        }
+        return rightsStatus != DrmStore.RightsStatus.RIGHTS_VALID;
+    }
+
     public int acquireRights(String assetUri, String licenseServerUri) {
 
         if (assetUri.startsWith("/")) {


### PR DESCRIPTION
i was unable to get rights on my Galaxy S5 device. i tried investigating the issue and tried the changes in this pull request.
i removed the rights in case it has invalid rights and re-acquire them again.
after that was done i was able to get rights and play the full WV media on that device.

(it **didn't** work on the S4 ver.5 device - it removed the invalid right, and failed again to acquire new ones on the DrmInfo processing) 