### PR TITLE
Placed guard to prevent accessing null object

### DIFF
--- a/playerSDK/src/main/java/com/kaltura/playersdk/PlayerViewController.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/PlayerViewController.java
@@ -846,6 +846,9 @@ public class PlayerViewController extends RelativeLayout implements KControlsVie
     }
 
     public void removeKPlayerEventListener(String event,String eventID) {
+        if (mPlayerEventsHash == null) {
+            return;
+        }
         ArrayList<HashMap<String, EventListener>> listenerArr = mPlayerEventsHash.get(event);
         if (listenerArr == null || listenerArr.size() == 0) {
             return;


### PR DESCRIPTION
This prevents an exception from being thrown if removeKPlayerEventListener is called before an event is registered through a call to addKPlayerEventListener.