### PR TITLE
TPE-11 - fix Exception in isSuppoted since some tailored Android has different params validation  

### DIFF
--- a/playerSDK/src/main/java/com/kaltura/playersdk/widevine/WidevineDrmClient.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/widevine/WidevineDrmClient.java
@@ -111,7 +111,7 @@ public class WidevineDrmClient {
     public static boolean isSupported(Context context) {
         DrmManagerClient drmManagerClient = new DrmManagerClient(context);
         boolean canHandle = false;
-        // adding try catch due to TPE-11 some not official android versions canHandle methos has unexpected behaviour in the arguments validation inside it
+        // adding try catch due some android devices have different canHandle method implementation regarding the arguments validation inside it
         try {
             canHandle = drmManagerClient.canHandle("", WIDEVINE_MIME_TYPE);
         } catch (IllegalArgumentException ex) {

--- a/playerSDK/src/main/java/com/kaltura/playersdk/widevine/WidevineDrmClient.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/widevine/WidevineDrmClient.java
@@ -11,6 +11,7 @@ import android.drm.DrmInfoRequest;
 import android.drm.DrmInfoStatus;
 import android.drm.DrmManagerClient;
 import android.drm.DrmStore;
+import android.os.Build;
 import android.text.TextUtils;
 
 import java.io.FileDescriptor;
@@ -109,12 +110,22 @@ public class WidevineDrmClient {
 
     public static boolean isSupported(Context context) {
         DrmManagerClient drmManagerClient = new DrmManagerClient(context);
-        boolean canHandle = drmManagerClient.canHandle("", WIDEVINE_MIME_TYPE);
-        drmManagerClient.release();
+        boolean canHandle = false;
+        // adding try catch due to TPE-11 some not official android versions canHandle methos has unexpected behaviour in the arguments validation inside it
+        try {
+            canHandle = drmManagerClient.canHandle("", WIDEVINE_MIME_TYPE);
+        } catch (IllegalArgumentException ex) {
+            LOGE(TAG, "drmManagerClient.canHandle failed");
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                LOGI(TAG, "Assuming WV Classic is supported although canHandle has failed");
+                canHandle = true;
+            }
+        } finally {
+            drmManagerClient.release();
+        }
         return canHandle;
     }
-    
-    
+
     public WidevineDrmClient(Context context) {
 
         mDrmManager = new DrmManagerClient(context) {


### PR DESCRIPTION
WidevineDrmClient.java line 112
com.kaltura.playersdk.widevine.WidevineDrmClient.isSupported
Fatal Exception: java.lang.IllegalArgumentException: Given path is invalid/null