### PR TITLE
Added static PlayerViewController.prefetchPlayerResources().

### DIFF
--- a/playerSDK/src/main/java/com/kaltura/playersdk/PlayerViewController.java
+++ b/playerSDK/src/main/java/com/kaltura/playersdk/PlayerViewController.java
@@ -101,6 +101,24 @@ public class PlayerViewController extends RelativeLayout implements KControlsVie
 
     private KCastProvider mCastProvider;
 
+    public static void prefetchPlayerResources(KPPlayerConfig config, Activity activity) {
+
+        final PlayerViewController player = new PlayerViewController(activity);
+
+        player.loadPlayerIntoActivity(activity);
+
+        config.addConfig("EmbedPlayer.PreloadNativeComponent", "true");
+        
+        player.initWithConfiguration(config);
+        
+        player.registerReadyEvent(new ReadyEventListener() {
+            @Override
+            public void handler() {
+                LOGD(TAG, "Player ready after prefetch - will now destroy player");
+                player.removePlayer();
+            }
+        });
+    }
 
 
     public void setCastProvider(KCastProvider castProvider) {


### PR DESCRIPTION
Allows the app to prefetch the player's resources.

Needs mwEmbed Player v2.48.